### PR TITLE
Fix VS Code install badge URLs for GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ claude mcp add atlassian-extended -- uvx mcp-atlassian-extended
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
 
+> The actual server config starts at `atlassian-extended` inside `mcpServers`.
+
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Replace `vscode:mcp/install` protocol links with `https://insiders.vscode.dev/redirect/mcp/install` HTTPS URLs
- GitHub's markdown sanitizer strips non-HTTP protocol links, causing badges to render as empty buttons
- This is the same format used by [github/github-mcp-server](https://github.com/github/github-mcp-server)