### PR TITLE
docs: implement IntelliJ install parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,27 @@ There is no tool overlap — this server only implements tools that mcp-atlassia
 claude mcp add atlassian-extended -- uvx mcp-atlassian-extended
 ```
 
-### VS Code
+### IntelliJ
 
-> IntelliJ one-click install support is planned for parity with VS Code/Cursor flows.
+In IntelliJ-based IDEs, add MCP config using a project `.mcp.json` file:
+
+```json
+{
+  "mcpServers": {
+    "atlassian-extended": {
+      "command": "uvx",
+      "args": ["mcp-atlassian-extended"],
+      "env": {
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "JIRA_API_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+### VS Code
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-atlassian-extended&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-atlassian-extended%22%5D%2C%22env%22%3A%7B%22JIRA_URL%22%3A%22%24%7Binput%3Ajira-url%7D%22%2C%22JIRA_USERNAME%22%3A%22%24%7Binput%3Ajira-username%7D%22%2C%22JIRA_API_TOKEN%22%3A%22%24%7Binput%3Ajira-api-token%7D%22%7D%7D) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-atlassian-extended&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-atlassian-extended%22%5D%2C%22env%22%3A%7B%22JIRA_URL%22%3A%22%24%7Binput%3Ajira-url%7D%22%2C%22JIRA_USERNAME%22%3A%22%24%7Binput%3Ajira-username%7D%22%2C%22JIRA_API_TOKEN%22%3A%22%24%7Binput%3Ajira-api-token%7D%22%7D%7D&quality=insiders)
 


### PR DESCRIPTION
## Summary
- remove placeholder IntelliJ parity note
- add concrete IntelliJ install section with project .mcp.json server config example
- keep VS Code/Cursor install sections unchanged

## Validation
- verified README renders with new IntelliJ section
- confirmed branch contains only README changes