### PR TITLE
chore: clean up documentation examples

### DIFF
--- a/src/mcp_atlassian_extended/servers/jira_issues.py
+++ b/src/mcp_atlassian_extended/servers/jira_issues.py
@@ -56,7 +56,7 @@ async def jira_create_issue(
 ) -> str:
     """Create a Jira issue with standard and custom fields.
 
-    custom_fields example: {"customfield_10004": 5, "customfield_17220": {"value": "SDM"}}
+    custom_fields example: {"customfield_10004": 5, "customfield_17220": {"value": "CustomValue"}}
     """
     try:
         _check_write(ctx)

--- a/tests/unit/test_jira_issues.py
+++ b/tests/unit/test_jira_issues.py
@@ -40,7 +40,7 @@ class TestJiraIssues:
             result = await client.create_issue(
                 "PROJ",
                 "Custom fields test",
-                custom_fields={"customfield_10004": 5, "customfield_17220": {"value": "SDM"}},
+                custom_fields={"customfield_10004": 5, "customfield_17220": {"value": "CustomValue"}},
             )
             assert result["key"] == "PROJ-2"
             sent_body = route.calls[0].request.content
@@ -48,7 +48,7 @@ class TestJiraIssues:
 
             payload = json.loads(sent_body)
             assert payload["fields"]["customfield_10004"] == 5
-            assert payload["fields"]["customfield_17220"] == {"value": "SDM"}
+            assert payload["fields"]["customfield_17220"] == {"value": "CustomValue"}
 
     @pytest.mark.asyncio
     async def test_update_issue(self):


### PR DESCRIPTION
Scrubbed specific acronyms from the documentation examples and test payloads to use a generic 'CustomValue' string instead.