### PR TITLE
docs: reorganize installation section and gateway link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,25 @@ This project runs alongside [mcp-atlassian](https://github.com/sooperset/mcp-atl
 
 There is no tool overlap — this server only implements tools that mcp-atlassian lacks.
 
-## Quick Install
+## 1-Click Installation
 
-> Prerequisite: Install `uv` first (required for all `uvx` install flows, including one-click Cursor/VS Code buttons). [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html?install=cursor)
 
-> **Tip:** For a unified installation experience across all IDEs, visit the **[MCP Installation Gateway](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html)**.
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html?install=vscode) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html?install=vscode-insiders)
 
-### Cursor
+> **💡 Tip:** For other AI assistants (Claude Code, Windsurf, IntelliJ), visit the **[Atlassian Extended MCP Installation Gateway](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html)**.
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html?install=cursor)
+<details>
+<summary><b>Manual Setup Guides (Click to expand)</b></summary>
+<br/>
+
+> Prerequisite: Install `uv` first (required for all `uvx` install flows). [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ### Claude Code
 
 ```bash
 claude mcp add atlassian-extended -- uvx mcp-atlassian-extended
 ```
-
-### VS Code
-
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html?install=vscode) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html?install=vscode-insiders)
 
 ### Windsurf & IntelliJ
 
@@ -70,6 +70,8 @@ claude mcp add atlassian-extended -- uvx mcp-atlassian-extended
 ```bash
 uv pip install mcp-atlassian-extended
 ```
+
+</details>
 
 ## Configuration
 


### PR DESCRIPTION
Moves the install badges to the top and puts the manual instructions inside a collapsible block, with a prominent link to the Installation Gateway.