### PR TITLE
feat: MCP tool annotations, shared helpers, tag/guard fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 .idea/
 .vscode/
 *.iml
+.claude/
+.cursorrules
+.cursor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,58 @@ Extended MCP tools for Jira and Confluence, complementing mcp-atlassian with 23 
 
 - **Entry point**: `src/mcp_atlassian_extended/__init__.py` — click CLI
 - **Clients**: `src/mcp_atlassian_extended/clients/` — `JiraExtendedClient`, `ConfluenceExtendedClient`
-- **Tools**: `src/mcp_atlassian_extended/servers/` — three modules: `jira_extended`, `jira_agile`, `confluence_extended`
+- **Tools**: `src/mcp_atlassian_extended/servers/` — four modules: `jira_extended`, `jira_agile`, `jira_issues`, `confluence_extended`
+- **Helpers**: `src/mcp_atlassian_extended/servers/_helpers.py` — shared `_get_jira`, `_get_confluence`, `_check_write`, `_ok`, `_err`
 - **Config**: `src/mcp_atlassian_extended/config.py` — `JiraConfig`, `ConfluenceConfig` from env
+
+## Patterns
+
+- All tools are `async def` returning JSON strings
+- Shared helpers extracted to `servers/_helpers.py` — all server modules import from there
+- Error handling: try/except wrapping every tool, returning `{"error": ...}` JSON
+- Write access control: `_check_write(ctx)` raises `WriteDisabledError` when `ATLASSIAN_READ_ONLY=true`
+- Tags: every tool tagged with `{"jira"|"confluence", "<category>", "read"|"write"}`
+- Parameters use `Annotated[type, Field(description=...)]`
+- Confluence tools include `_resolve_date()` for relative dates ("today", "+14d", "next week")
+
+## MCP Compliance Rules
+
+### Tool Annotations (MANDATORY)
+Every tool MUST have `annotations={}` with at minimum `readOnlyHint`.
+- Read tools: `annotations={"readOnlyHint": True, "idempotentHint": True}`
+- Non-destructive write tools: `annotations={"readOnlyHint": False}`
+- Destructive write tools: `annotations={"destructiveHint": True, "readOnlyHint": False}`
+- Idempotent writes (PUT/update): add `idempotentHint: True`
+
+### Tool Descriptions
+- 1-2 sentences. Front-load what it does AND what it returns.
+- Bad: "This tool gets attachments."
+- Good: "List attachments on a Jira issue. Returns id, filename, size, content URL."
+
+### Error Handling
+- Every tool MUST wrap in try/except and return `_err(e)` — never raise.
+- Error text MUST be actionable: include what went wrong and suggest a fix.
+- Never expose stack traces, tokens, or internal paths.
+
+### Parameter Design
+- Use `Annotated[type, Field(description="...")]` on every parameter.
+- Use `Literal[...]` for known value sets instead of plain `str`.
+- Every optional parameter must have a default.
+- Flatten — no nested dicts unless truly necessary (like `custom_fields`).
+
+### Read-Only Mode
+- Every write tool MUST call `_check_write(ctx)` before any mutation.
+- `jira_download_attachment` is tagged "write" because it writes to local disk.
+
+### Naming Convention
+- Pattern: `{service}_{verb}_{resource}` (snake_case)
+- Verbs: create, get, list, search, update, delete, move, upload, download
+
+### Adding New Tools
+- Add to the appropriate server module (or create a new one registered in `servers/__init__.py`)
+- Import helpers from `._helpers` — never duplicate `_get_jira`, `_ok`, `_err`, etc.
+- Always include `annotations={}` on the `@mcp.tool()` decorator
+- Tag with service, category, and read/write
 
 ## Tool Categories
 
@@ -26,3 +76,10 @@ Extended MCP tools for Jira and Confluence, complementing mcp-atlassian with 23 
 - `CONFLUENCE_URL` + `CONFLUENCE_USERNAME` + `CONFLUENCE_API_TOKEN` — Confluence Cloud
 - `CONFLUENCE_URL` + `CONFLUENCE_PAT` — Confluence Data Center
 - `ATLASSIAN_READ_ONLY` — disable mutations
+
+## Known Limitations / Future Work
+
+- `models/` package is empty. Define Pydantic response models if response trimming is needed.
+- No tool-level tests. Client and config tests exist.
+- `jira_search_users` uses `username` parameter which may not work on Jira Cloud v3 (works on Data Center).
+- Errors are returned as successful tool results with `{"error": ...}` (soft-error pattern). Callers must inspect JSON content.

--- a/src/mcp_atlassian_extended/servers/_helpers.py
+++ b/src/mcp_atlassian_extended/servers/_helpers.py
@@ -1,0 +1,44 @@
+"""Shared helpers for all server modules."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastmcp import Context
+
+from ..clients.confluence import ConfluenceExtendedClient
+from ..clients.jira import JiraExtendedClient
+from ..exceptions import WriteDisabledError
+
+
+def _get_jira(ctx: Context) -> JiraExtendedClient:
+    client = ctx.request_context.lifespan_context["jira_client"]
+    if client is None:
+        msg = "Jira is not configured. Set JIRA_URL and JIRA_PAT environment variables."
+        raise ValueError(msg)
+    return client
+
+
+def _get_confluence(ctx: Context) -> ConfluenceExtendedClient:
+    client = ctx.request_context.lifespan_context["confluence_client"]
+    if client is None:
+        msg = (
+            "Confluence is not configured."
+            " Set CONFLUENCE_URL and CONFLUENCE_PAT environment variables."
+        )
+        raise ValueError(msg)
+    return client
+
+
+def _check_write(ctx: Context) -> None:
+    if ctx.request_context.lifespan_context["jira_config"].read_only:
+        raise WriteDisabledError
+
+
+def _ok(data: Any) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def _err(error: Exception) -> str:
+    return json.dumps({"error": str(error)}, indent=2, ensure_ascii=False)

--- a/src/mcp_atlassian_extended/servers/confluence_extended.py
+++ b/src/mcp_atlassian_extended/servers/confluence_extended.py
@@ -2,35 +2,15 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timedelta
-from typing import Annotated, Any
+from typing import Annotated
 
 from dateutil.parser import parse as parse_date
 from fastmcp import Context
 from pydantic import Field
 
-from ..clients.confluence import ConfluenceExtendedClient
 from . import mcp
-
-
-def _get_confluence(ctx: Context) -> ConfluenceExtendedClient:
-    client = ctx.request_context.lifespan_context["confluence_client"]
-    if client is None:
-        msg = (
-            "Confluence is not configured."
-            " Set CONFLUENCE_URL and CONFLUENCE_PAT environment variables."
-        )
-        raise ValueError(msg)
-    return client
-
-
-def _ok(data: Any) -> str:
-    return json.dumps(data, indent=2, ensure_ascii=False)
-
-
-def _err(error: Exception) -> str:
-    return json.dumps({"error": str(error)}, indent=2, ensure_ascii=False)
+from ._helpers import _err, _get_confluence, _ok
 
 
 def _resolve_date(value: str) -> str:
@@ -56,7 +36,10 @@ def _resolve_date(value: str) -> str:
     return parse_date(value).strftime("%Y-%m-%d")
 
 
-@mcp.tool(tags={"confluence", "calendars", "read"})
+@mcp.tool(
+    tags={"confluence", "calendars", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def confluence_list_calendars(
     ctx: Context,
     filter_type: Annotated[
@@ -95,7 +78,10 @@ async def confluence_list_calendars(
         return _err(e)
 
 
-@mcp.tool(tags={"confluence", "calendars", "read"})
+@mcp.tool(
+    tags={"confluence", "calendars", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def confluence_search_calendars(
     ctx: Context,
     query: Annotated[str, Field(description="Search by calendar name, space name, or space key")],
@@ -126,7 +112,10 @@ async def confluence_search_calendars(
         return _err(e)
 
 
-@mcp.tool(tags={"confluence", "time_off", "read"})
+@mcp.tool(
+    tags={"confluence", "time_off", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def confluence_get_time_off(
     ctx: Context,
     start_date: Annotated[str, Field(description="Start date (YYYY-MM-DD, 'today', '+14d', etc.)")],
@@ -152,7 +141,10 @@ async def confluence_get_time_off(
         return _err(e)
 
 
-@mcp.tool(tags={"confluence", "time_off", "read"})
+@mcp.tool(
+    tags={"confluence", "time_off", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def confluence_who_is_out(
     ctx: Context,
     date: Annotated[str, Field(description="Date to check (default: 'today')")] = "today",
@@ -167,7 +159,10 @@ async def confluence_who_is_out(
         return _err(e)
 
 
-@mcp.tool(tags={"confluence", "time_off", "read"})
+@mcp.tool(
+    tags={"confluence", "time_off", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def confluence_get_person_time_off(
     ctx: Context,
     person: Annotated[str, Field(description="Person name to search for")],
@@ -187,7 +182,10 @@ async def confluence_get_person_time_off(
         return _err(e)
 
 
-@mcp.tool(tags={"confluence", "time_off", "read"})
+@mcp.tool(
+    tags={"confluence", "time_off", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def confluence_sprint_capacity(
     ctx: Context,
     team_members: Annotated[list[str], Field(description="List of team member names")],

--- a/src/mcp_atlassian_extended/servers/jira_agile.py
+++ b/src/mcp_atlassian_extended/servers/jira_agile.py
@@ -2,39 +2,19 @@
 
 from __future__ import annotations
 
-import json
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastmcp import Context
 from pydantic import Field
 
-from ..clients.jira import JiraExtendedClient
-from ..exceptions import WriteDisabledError
 from . import mcp
+from ._helpers import _check_write, _err, _get_jira, _ok
 
 
-def _get_jira(ctx: Context) -> JiraExtendedClient:
-    client = ctx.request_context.lifespan_context["jira_client"]
-    if client is None:
-        msg = "Jira is not configured. Set JIRA_URL and JIRA_PAT environment variables."
-        raise ValueError(msg)
-    return client
-
-
-def _check_write(ctx: Context) -> None:
-    if ctx.request_context.lifespan_context["jira_config"].read_only:
-        raise WriteDisabledError
-
-
-def _ok(data: Any) -> str:
-    return json.dumps(data, indent=2, ensure_ascii=False)
-
-
-def _err(error: Exception) -> str:
-    return json.dumps({"error": str(error)}, indent=2, ensure_ascii=False)
-
-
-@mcp.tool(tags={"jira", "agile", "read"})
+@mcp.tool(
+    tags={"jira", "agile", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def jira_get_board(
     ctx: Context,
     board_id: Annotated[int, Field(description="Board ID")],
@@ -47,7 +27,10 @@ async def jira_get_board(
         return _err(e)
 
 
-@mcp.tool(tags={"jira", "agile", "read"})
+@mcp.tool(
+    tags={"jira", "agile", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def jira_board_config(
     ctx: Context,
     board_id: Annotated[int, Field(description="Board ID")],
@@ -60,7 +43,10 @@ async def jira_board_config(
         return _err(e)
 
 
-@mcp.tool(tags={"jira", "agile", "read"})
+@mcp.tool(
+    tags={"jira", "agile", "read"},
+    annotations={"readOnlyHint": True, "idempotentHint": True},
+)
 async def jira_get_sprint(
     ctx: Context,
     sprint_id: Annotated[int, Field(description="Sprint ID")],
@@ -73,7 +59,7 @@ async def jira_get_sprint(
         return _err(e)
 
 
-@mcp.tool(tags={"jira", "agile", "write"})
+@mcp.tool(tags={"jira", "agile", "write"}, annotations={"readOnlyHint": False})
 async def jira_move_to_sprint(
     ctx: Context,
     sprint_id: Annotated[int, Field(description="Target sprint ID")],

--- a/tests/unit/test_jira_issues.py
+++ b/tests/unit/test_jira_issues.py
@@ -42,7 +42,7 @@ class TestJiraIssues:
                 "Custom fields test",
                 custom_fields={
                     "customfield_10004": 5,
-                    "customfield_17220": {"value": "CustomValue"},
+                    "customfield_12345": {"value": "MyTeam"},
                 },
             )
             assert result["key"] == "PROJ-2"
@@ -51,7 +51,7 @@ class TestJiraIssues:
 
             payload = json.loads(sent_body)
             assert payload["fields"]["customfield_10004"] == 5
-            assert payload["fields"]["customfield_17220"] == {"value": "CustomValue"}
+            assert payload["fields"]["customfield_12345"] == {"value": "MyTeam"}
 
     @pytest.mark.asyncio
     async def test_update_issue(self):

--- a/uv.lock
+++ b/uv.lock
@@ -816,7 +816,7 @@ wheels = [
 
 [[package]]
 name = "mcp-atlassian-extended"
-version = "0.1.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add `readOnlyHint`, `destructiveHint`, `idempotentHint` annotations to all 23 tools
- Extract shared helpers to `servers/_helpers.py` — eliminates duplication across 4 server modules
- Fix `jira_download_attachment`: tag corrected from `"read"` to `"write"` (writes to local disk), add `_check_write` guard
- Fix proprietary data in docstring and tests (use generic `customfield_12345`/`MyTeam`)
- Update AGENTS.md with MCP compliance rules, correct tool count (22 → 23)
- Add `.claude/`, `.cursor/`, `.cursorrules` to `.gitignore`

## Annotation breakdown
| Category | Count | Annotation |
|----------|-------|------------|
| Read tools | 14 | `readOnlyHint: True, idempotentHint: True` |
| Non-destructive writes | 6 | `readOnlyHint: False` |
| Idempotent writes | 1 | `readOnlyHint: False, idempotentHint: True` |
| Destructive writes | 2 | `destructiveHint: True, readOnlyHint: False` |

## Test plan
- [x] `uv run pytest` — 30 passed
- [x] `uv run ruff check .` — all checks passed
- [x] Reference scan clean (no proprietary data)