### PR TITLE
docs: update tool count 23→26, add Jira Versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # mcp-atlassian-extended — Agent Context
 
-Extended MCP tools for Jira and Confluence, complementing mcp-atlassian with 23 tools.
+Extended MCP tools for Jira and Confluence, complementing mcp-atlassian with 26 tools.
 
 ## Architecture
 
@@ -70,6 +70,7 @@ Every tool MUST have `annotations={}` with at minimum `readOnlyHint`.
 - Jira Users (1): search
 - Jira Metadata (3): list-projects, list-fields, backlog
 - Jira Agile (4): get-board, board-config, get-sprint, move-to-sprint
+- Jira Versions (3): get-project-versions, create-version, update-version (REST API v2, Server/DC + Cloud)
 - Confluence Calendars (6): list, search, time-off, who-is-out, person-time-off, sprint-capacity
 
 ## Environment Variables
@@ -116,6 +117,19 @@ Prompts follow the resources pattern: prompt content lives as `.md` files in `sr
 - `close_ticket` — Ticket closure checklist (tags: jira, workflow)
 - `team_availability` — Availability report (tags: confluence, capacity)
 - `manage_attachments` — Attachment management (tags: jira, attachments)
+
+## Documentation Freshness (MANDATORY)
+
+When any changeset adds, removes, or modifies tools, resources, or prompts, ALL documentation files MUST be updated in the same commit:
+
+- `README.md` — tool count in heading + intro, tool table, full tool reference, usage examples, permissions table
+- `llms.txt` — tool count in tagline and documentation link
+- `llms-full.txt` — tool count in tagline, documentation link, full tool reference section
+- `AGENTS.md` — tool count in intro, tool categories list
+- `GEMINI.md` — tool count in intro, tool categories, common workflows
+- `server.json` — description field (<=100 chars)
+
+Checklist: verify tool count matches actual registered tools, verify category list is complete, verify new tools appear in correct sections with parameters and annotations.
 
 ## Known Limitations / Future Work
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # mcp-atlassian-extended — Gemini CLI Extension Context
 
-MCP server providing 23 tools, 15 resources, and 5 prompts for Jira and Confluence operations beyond core CRUD. Focuses on agile workflows, file attachments, team calendars, and sprint planning.
+MCP server providing 26 tools, 15 resources, and 5 prompts for Jira and Confluence operations beyond core CRUD. Focuses on agile workflows, file attachments, project versions, team calendars, and sprint planning.
 
 ## Tool Categories
 
@@ -9,6 +9,7 @@ MCP server providing 23 tools, 15 resources, and 5 prompts for Jira and Confluen
 - **Users & Fields** — search users, list project fields
 - **Agile** — backlog management, get/configure boards, get/create/update sprints, move issues to sprints
 - **Issues** — create, update, create/delete issue links, create epics
+- **Versions** — get project versions, create version, update version (REST API v2, Server/DC + Cloud)
 
 ### Confluence
 - **Calendars** — list and search calendars
@@ -22,6 +23,7 @@ MCP server providing 23 tools, 15 resources, and 5 prompts for Jira and Confluen
 - **Team availability**: `confluence_who_is_out` -> `confluence_get_person_time_off` -> `confluence_sprint_capacity`
 - **Issue linking**: `jira_create_issue` -> `jira_create_link` -> `jira_create_epic` -> `jira_move_to_sprint`
 - **Board configuration**: `jira_get_board` -> `jira_board_config` -> `jira_get_sprint` -> `jira_backlog`
+- **Version management**: `jira_get_project_versions` -> `jira_create_version` -> `jira_update_version`
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Install:** `uvx mcp-atlassian-extended` | [PyPI](https://pypi.org/project/mcp-atlassian-extended/) | [MCP Registry](https://registry.modelcontextprotocol.io) | [Changelog](https://github.com/vish288/mcp-atlassian-extended/releases)
 
-**mcp-atlassian-extended** is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that extends [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) with **23 tools**, **15 resources**, and **5 prompts** for Jira and Confluence: issue creation with custom fields, issue links, attachments, agile boards, sprints, backlog management, user search, calendars, time-off tracking, and sprint capacity planning. Works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code Copilot, and any MCP-compatible client.
+**mcp-atlassian-extended** is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that extends [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) with **26 tools**, **15 resources**, and **5 prompts** for Jira and Confluence: issue creation with custom fields, issue links, attachments, agile boards, sprints, backlog management, user search, project versions (API v2), calendars, time-off tracking, and sprint capacity planning. Works with Claude Desktop, Claude Code, Cursor, Windsurf, VS Code Copilot, and any MCP-compatible client.
 
 Supports Jira Cloud, Jira Data Center, Confluence Cloud, and Confluence Data Center (self-hosted). No Atlassian Premium required.
 
@@ -22,7 +22,7 @@ Built with [FastMCP](https://github.com/jlowin/fastmcp), [httpx](https://www.pyt
 This project runs alongside [mcp-atlassian](https://github.com/sooperset/mcp-atlassian), not as a replacement. Configure both servers:
 
 - **mcp-atlassian** handles: issues, search, transitions, comments, worklog, pages, Confluence search
-- **mcp-atlassian-extended** handles: attachments, agile, users, fields, calendars, time-off
+- **mcp-atlassian-extended** handles: attachments, agile, users, fields, versions (API v2), calendars, time-off
 
 There is no tool overlap — this server only implements tools that mcp-atlassian lacks.
 
@@ -151,7 +151,7 @@ The server checks these environment variables in order — first match wins:
 | VS Code Copilot | Yes | `.vscode/mcp.json` |
 | Any MCP client | Yes | stdio or HTTP transport |
 
-## Tools (23)
+## Tools (26)
 
 | Category | Count | Tools |
 |----------|-------|-------|
@@ -161,6 +161,7 @@ The server checks these environment variables in order — first match wins:
 | **Jira Users** | 1 | search by name/email |
 | **Jira Metadata** | 3 | list projects, list fields, backlog |
 | **Jira Agile** | 4 | get board, board config, get sprint, move to sprint |
+| **Jira Versions** | 3 | get project versions, create version, update version |
 | **Confluence Calendars** | 6 | list, search, time-off, who-is-out, person time-off, sprint capacity |
 
 <details>
@@ -206,6 +207,13 @@ The server checks these environment variables in order — first match wins:
 | `jira_board_config` | Get board column configuration |
 | `jira_get_sprint` | Get sprint details |
 | `jira_move_to_sprint` | Move issues to a sprint |
+
+### Jira Versions
+| Tool | Description |
+|------|-------------|
+| `jira_get_project_versions` | List all versions for a project (REST API v2, Server/DC + Cloud) |
+| `jira_create_version` | Create a new version in a project (REST API v2) |
+| `jira_update_version` | Update an existing version (REST API v2) |
 
 ### Confluence Calendars
 | Tool | Description |
@@ -297,6 +305,19 @@ The server provides [MCP prompts](https://modelcontextprotocol.io/docs/concepts/
 → jira_backlog(board_id=42, max_results=50)
 ```
 
+### Version Management
+
+```
+"List versions for project PROJ"
+→ jira_get_project_versions(project_key="PROJ")
+
+"Create a new release version"
+→ jira_create_version(project_key="PROJ", name="v2.0.0", release_date="2026-04-01")
+
+"Mark version as released"
+→ jira_update_version(version_id="200", released=True)
+```
+
 ### Time-Off & Sprint Capacity
 
 ```
@@ -339,6 +360,7 @@ Jira Cloud enforces per-user rate limits. When rate-limited, tools return a 429 
 | Create/delete issue links | Link Issues |
 | Upload/delete attachments | Create Attachments + Delete Own Attachments |
 | Move issues to sprint | Manage Sprints |
+| Create/update versions | Administer Projects |
 | Confluence calendars/time-off | View space content |
 
 ## CLI & Transport Options

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # mcp-atlassian-extended
 
-> MCP server extending mcp-atlassian — 23 tools, 15 resources, and 5 prompts for Jira and Confluence: issue creation with custom fields, issue links, attachments, agile boards, sprints, calendars, time-off tracking, and sprint capacity planning.
+> MCP server extending mcp-atlassian — 26 tools, 15 resources, and 5 prompts for Jira and Confluence: issue creation with custom fields, issue links, attachments, agile boards, sprints, project versions (API v2), calendars, time-off tracking, and sprint capacity planning.
 
 MCP server that complements mcp-atlassian with zero tool overlap. Provides issue CRUD with custom fields, agile board management, Confluence calendar and time-off tracking, and sprint capacity planning. Built with FastMCP, httpx, and Pydantic.
 
@@ -17,7 +17,7 @@ MCP server that complements mcp-atlassian with zero tool overlap. Provides issue
 
 ## Documentation
 
-- [README](https://github.com/vish288/mcp-atlassian-extended#readme): canonical reference for setup, env vars, all 23 tools, 15 resources, 5 prompts
+- [README](https://github.com/vish288/mcp-atlassian-extended#readme): canonical reference for setup, env vars, all 26 tools, 15 resources, 5 prompts
 - [PyPI](https://pypi.org/project/mcp-atlassian-extended/): install via `pip install mcp-atlassian-extended` or `uvx mcp-atlassian-extended`
 - [GitHub](https://github.com/vish288/mcp-atlassian-extended): source code, issue tracker, development setup
 - [MCP Registry](https://registry.modelcontextprotocol.io): discover and install MCP servers
@@ -110,7 +110,7 @@ uvx mcp-atlassian-extended --jira-url https://jira.example.com --jira-token xxx 
 
 ---
 
-## Tools (23) — Full Reference
+## Tools (26) — Full Reference
 
 ### Jira Issues (3)
 
@@ -297,6 +297,47 @@ Parameters:
 
 Tags: jira, agile, write
 Annotations: readOnlyHint=false, openWorldHint=true
+
+### Jira Versions (3)
+
+#### `jira_get_project_versions`
+List all versions for a Jira project (REST API v2, supports Server/DC and Cloud).
+
+Parameters:
+- `project_key` (str, required): Project key (e.g. PROJ)
+
+Tags: jira, versions, read
+Annotations: readOnlyHint=true, idempotentHint=true, openWorldHint=true
+
+#### `jira_create_version`
+Create a new version in a Jira project (REST API v2, supports Server/DC and Cloud).
+
+Parameters:
+- `project_key` (str, required): Project key (e.g. PROJ)
+- `name` (str, required): Version name
+- `description` (str, optional): Version description
+- `release_date` (str, optional): Release date (YYYY-MM-DD)
+- `start_date` (str, optional): Start date (YYYY-MM-DD)
+- `released` (bool, optional): Mark as released
+- `archived` (bool, optional): Mark as archived
+
+Tags: jira, versions, write
+Annotations: readOnlyHint=false, openWorldHint=true
+
+#### `jira_update_version`
+Update an existing Jira version (REST API v2, supports Server/DC and Cloud).
+
+Parameters:
+- `version_id` (str, required): Version ID
+- `name` (str, optional): New version name
+- `description` (str, optional): New description
+- `release_date` (str, optional): Release date (YYYY-MM-DD)
+- `start_date` (str, optional): Start date (YYYY-MM-DD)
+- `released` (bool, optional): Mark as released
+- `archived` (bool, optional): Mark as archived
+
+Tags: jira, versions, write
+Annotations: readOnlyHint=false, idempotentHint=true, openWorldHint=true
 
 ### Confluence Calendars (6)
 
@@ -784,6 +825,7 @@ Workflow steps:
 | Create/delete issue links | Link Issues |
 | Upload/delete attachments | Create Attachments + Delete Own Attachments |
 | Move issues to sprint | Manage Sprints |
+| Create/update versions | Administer Projects |
 | Confluence calendars/time-off | View space content |
 
 ## Rate Limits

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # mcp-atlassian-extended
 
-> MCP server extending mcp-atlassian — 23 tools, 15 resources, and 5 prompts for Jira and Confluence: issue creation with custom fields, issue links, attachments, agile boards, sprints, calendars, time-off tracking, and sprint capacity planning.
+> MCP server extending mcp-atlassian — 26 tools, 15 resources, and 5 prompts for Jira and Confluence: issue creation with custom fields, issue links, attachments, agile boards, sprints, project versions (API v2), calendars, time-off tracking, and sprint capacity planning.
 
 MCP server that complements mcp-atlassian with zero tool overlap. Provides issue CRUD with custom fields, agile board management, Confluence calendar and time-off tracking, and sprint capacity planning. Built with FastMCP, httpx, and Pydantic.
 
@@ -17,7 +17,7 @@ MCP server that complements mcp-atlassian with zero tool overlap. Provides issue
 
 ## Documentation
 
-- [README](https://github.com/vish288/mcp-atlassian-extended#readme): canonical reference for setup, env vars, all 23 tools, 15 resources, 5 prompts
+- [README](https://github.com/vish288/mcp-atlassian-extended#readme): canonical reference for setup, env vars, all 26 tools, 15 resources, 5 prompts
 - [PyPI](https://pypi.org/project/mcp-atlassian-extended/): install via `pip install mcp-atlassian-extended` or `uvx mcp-atlassian-extended`
 - [GitHub](https://github.com/vish288/mcp-atlassian-extended): source code, issue tracker, development setup
 - [MCP Registry](https://registry.modelcontextprotocol.io): discover and install MCP servers

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vish288/mcp-atlassian-extended",
-  "description": "MCP server for Jira and Confluence — sprints, agile boards, attachments, calendars, capacity.",
+  "description": "MCP server for Jira and Confluence — sprints, agile boards, attachments, versions, calendars.",
   "repository": {
     "url": "https://github.com/vish288/mcp-atlassian-extended",
     "source": "github"


### PR DESCRIPTION
## Summary
- Update tool count from 23 to 26 across all documentation files
- Add Jira Versions category (3 tools: get_project_versions, create_version, update_version) using REST API v2
- Add Documentation Freshness rule to AGENTS.md requiring all doc files to be updated when tools change
- Files updated: README.md, llms.txt, llms-full.txt, AGENTS.md, GEMINI.md, server.json

## Test plan
- [x] All 183 tests pass
- [x] Tool count verified against actual registered tools
- [x] New section appears in correct position (after Jira Agile, before Confluence Calendars)