### PR TITLE
fix: sync server.json/gemini-extension.json versions, auto-bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,29 @@ jobs:
             [ -f "$f" ] && sed -i 's/^- \*\*Version\*\*: .*/- **Version**: ${{ steps.next.outputs.version }}/' "$f"
           done
 
+      - name: Update server.json and gemini-extension.json versions
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          python - <<'PY'
+          import json, os
+          v = os.environ["NEXT_VERSION"]
+          with open("server.json") as f:
+              data = json.load(f)
+          data["version"] = v
+          for pkg in data.get("packages", []):
+              pkg["version"] = v
+          with open("server.json", "w") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+          with open("gemini-extension.json") as f:
+              data = json.load(f)
+          data["version"] = v
+          with open("gemini-extension.json", "w") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+          PY
+
       - name: Regenerate uv.lock
         run: uv lock
 
@@ -165,6 +188,8 @@ jobs:
           CHANGELOG_BLOB=$(create_blob CHANGELOG.md)
           LLMS_BLOB=$(create_blob llms.txt)
           LLMS_FULL_BLOB=$(create_blob llms-full.txt)
+          SERVER_JSON_BLOB=$(create_blob server.json)
+          GEMINI_EXT_BLOB=$(create_blob gemini-extension.json)
 
           # Create tree with all release files
           NEW_TREE=$(gh api repos/${{ github.repository }}/git/trees \
@@ -202,6 +227,18 @@ jobs:
                 "mode": "100644",
                 "type": "blob",
                 "sha": "$LLMS_FULL_BLOB"
+              },
+              {
+                "path": "server.json",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "$SERVER_JSON_BLOB"
+              },
+              {
+                "path": "gemini-extension.json",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "$GEMINI_EXT_BLOB"
               }
             ]
           }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-atlassian-extended",
-  "version": "0.6.7",
+  "version": "0.6.13",
   "description": "Extended MCP tools for Jira and Confluence — attachments, agile boards, sprints, calendars",
   "mcpServers": {
     "mcp-atlassian-extended": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/vish288/mcp-atlassian-extended",
     "source": "github"
   },
-  "version": "0.6.7",
+  "version": "0.6.13",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-atlassian-extended",
-      "version": "0.6.7",
+      "version": "0.6.13",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Sync `server.json` and `gemini-extension.json` versions from `0.6.7` → `0.6.13` (they drifted because the release workflow never touched them).
- Extend `release.yml` to bump and commit both manifests on every release so the drift cannot reappear.

## Drift root cause
The `Semantic Release` workflow only updated `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, `llms.txt`, and `llms-full.txt`. The MCP Registry manifest (`server.json`) and Gemini CLI extension manifest (`gemini-extension.json`) both carry a `version` field that was last hand-edited at 0.6.7 (PR #36/#37) and has been stale through 6 subsequent releases.

## Test plan
- [x] `python -c "import json; json.load(open('server.json')); json.load(open('gemini-extension.json'))"` — both still valid JSON
- [ ] After merge: dispatch release workflow with `bump=patch` and confirm both files end up with the new version in the release commit